### PR TITLE
generators: change output to start under /cpm_out/ folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ cpm download manifest -c 0x4380f2c1de98bb267d3ea821897ec571a04fe3e0 -N https://m
 cpm generate -m samplecontract.manifest.json -l python
 cpm generate -m samplecontract.manifest.json -l go
 ```
-Note: the SDKs are placed in a language specific folder i.e. `/python/<contract>` or `/golang/<contract>`
+Note: all the SDKs are placed in `/cpm_out/` under a language specific folder i.e. `/cpm_out/python/<contract>` or `/cpm_out/golang/<contract>`

--- a/generators/common.go
+++ b/generators/common.go
@@ -2,13 +2,16 @@ package generators
 
 import (
 	"fmt"
-	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
-	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
-	"github.com/nspcc-dev/neo-go/pkg/util"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+	"github.com/nspcc-dev/neo-go/pkg/util"
 )
+
+const OutputRoot = "cpm_out/"
 
 // Big chunks of code gracefully borrowed from neo-go <3 with some adjustments
 

--- a/generators/csharp.go
+++ b/generators/csharp.go
@@ -2,11 +2,12 @@ package generators
 
 import (
 	"fmt"
+	"os"
+	"text/template"
+
 	"github.com/iancoleman/strcase"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	log "github.com/sirupsen/logrus"
-	"os"
-	"text/template"
 )
 
 const csharpSrcTmpl = `
@@ -67,20 +68,21 @@ func GenerateCsharpSDK(cfg *GenerateCfg) error {
 		return err
 	}
 
-	sdkLocation := wd + "/csharp/" + upperFirst(cfg.Manifest.Name) + ".cs"
+	sdkLocation := wd + "/" + OutputRoot + "csharp/" + upperFirst(cfg.Manifest.Name) + ".cs"
 	log.Infof("Created SDK for contract '%s' at %s with contract hash 0x%s", cfg.Manifest.Name, sdkLocation, cfg.ContractHash.StringLE())
 
 	return nil
 }
 
 func createCsharpPackage(cfg *GenerateCfg) error {
-	err := os.MkdirAll("csharp/cpm/", 0755)
+	dir := OutputRoot + "csharp/cpm/"
+	err := os.MkdirAll(dir, 0755)
 	if err != nil {
-		return fmt.Errorf("can't create directory %s: %w", cfg.Manifest.Name, err)
+		return fmt.Errorf("can't create directory %s: %w", dir, err)
 	}
 
 	filename := upperFirst(cfg.Manifest.Name)
-	f, err := os.Create(fmt.Sprintf("csharp/cpm/%s.cs", filename))
+	f, err := os.Create(fmt.Sprintf(dir+"%s.cs", filename))
 	if err != nil {
 		f.Close()
 		return fmt.Errorf("can't create %s.cs file: %w", filename, err)

--- a/generators/golang.go
+++ b/generators/golang.go
@@ -2,10 +2,11 @@ package generators
 
 import (
 	"fmt"
-	"github.com/nspcc-dev/neo-go/pkg/smartcontract/binding"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
+
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/binding"
+	log "github.com/sirupsen/logrus"
 )
 
 func GenerateGoSDK(cfg *GenerateCfg) error {
@@ -13,12 +14,13 @@ func GenerateGoSDK(cfg *GenerateCfg) error {
 	goconfig.Manifest = cfg.Manifest
 	goconfig.Hash = cfg.ContractHash
 
-	err := os.Mkdir("golang", 0755)
+	dir := OutputRoot + "golang/"
+	err := os.Mkdir(dir, 0755)
 	if err != nil {
-		return fmt.Errorf("can't create directory %s: %w", cfg.Manifest.Name, err)
+		return fmt.Errorf("can't create directory %s: %w", dir, err)
 	}
 
-	f, err := os.Create("golang/" + strings.ToLower(cfg.Manifest.Name) + ".go")
+	f, err := os.Create(dir + strings.ToLower(cfg.Manifest.Name) + ".go")
 	if err != nil {
 		return fmt.Errorf("can't create output file: %w", err)
 	}
@@ -36,7 +38,7 @@ func GenerateGoSDK(cfg *GenerateCfg) error {
 		return err
 	}
 
-	sdkLocation := wd + "/golang/" + strings.ToLower(cfg.Manifest.Name) + ".go"
+	sdkLocation := wd + "/" + dir + strings.ToLower(cfg.Manifest.Name) + ".go"
 	log.Infof("Created SDK for contract '%s' at %s with contract hash 0x%s", cfg.Manifest.Name, sdkLocation, cfg.ContractHash.StringLE())
 	return nil
 }

--- a/generators/java.go
+++ b/generators/java.go
@@ -2,12 +2,13 @@ package generators
 
 import (
 	"fmt"
-	"github.com/iancoleman/strcase"
-	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"text/template"
+
+	"github.com/iancoleman/strcase"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	log "github.com/sirupsen/logrus"
 )
 
 const javaSrcTmpl = `
@@ -67,19 +68,20 @@ func GenerateJavaSDK(cfg *GenerateCfg) error {
 		return err
 	}
 
-	log.Infof("Created SDK for contract '%s' at %s/java/ with contract hash 0x%s", cfg.Manifest.Name, wd, cfg.ContractHash.StringLE())
+	log.Infof("Created SDK for contract '%s' at %sjava/ with contract hash 0x%s", cfg.Manifest.Name, wd+"/"+OutputRoot, cfg.ContractHash.StringLE())
 
 	return nil
 }
 
 func createJavaPackage(cfg *GenerateCfg) error {
-	err := os.Mkdir("java", 0755)
+	dir := OutputRoot + "java/"
+	err := os.MkdirAll(dir, 0755)
 	if err != nil {
-		return fmt.Errorf("can't create directory %s: %w", cfg.Manifest.Name, err)
+		return fmt.Errorf("can't create directory %s: %w", dir, err)
 	}
 
 	filename := upperFirst(cfg.Manifest.Name)
-	f, err := os.Create(fmt.Sprintf("java/%s.java", filename))
+	f, err := os.Create(fmt.Sprintf(dir+"%s.java", filename))
 	if err != nil {
 		f.Close()
 		return fmt.Errorf("can't create %s.java file: %w", filename, err)

--- a/generators/python.go
+++ b/generators/python.go
@@ -72,7 +72,7 @@ func GeneratePythonSDK(cfg *GenerateCfg) error {
 	if err != nil {
 		return err
 	}
-	sdkLocation := wd + "/python/" + upperFirst(cfg.Manifest.Name)
+	sdkLocation := wd + "/" + OutputRoot + "python/" + upperFirst(cfg.Manifest.Name)
 	log.Infof("Created SDK for contract '%s' at %s with contract hash 0x%s", cfg.Manifest.Name, sdkLocation, cfg.ContractHash.StringLE())
 
 	return nil
@@ -80,7 +80,7 @@ func GeneratePythonSDK(cfg *GenerateCfg) error {
 
 // create the Python package structure and set the ContractOutput to the open file handle
 func createPythonPackage(cfg *GenerateCfg) error {
-	baseDir := "python/"
+	baseDir := OutputRoot + "python/"
 	sdkDir := baseDir + cfg.Manifest.Name
 	err := os.MkdirAll(sdkDir, 0755)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -6,13 +6,14 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
-	"os"
-	"strings"
 )
 
 var (


### PR DESCRIPTION
Based on feedback it appeared to be slightly confusing to suddenly have a `/python/` folder in your project folder (e.g. when generating SDKs with `Python` as output language). This PR adds a root output folder.

**Previous output**
`/project_root/<language name>/<sdk_name>/`

**New output**
`/project_root/cpm_out/<language>/<sdk_name>/`