### PR TITLE
python: fix generated contract methods

### DIFF
--- a/generators/python.go
+++ b/generators/python.go
@@ -27,7 +27,8 @@ import (
 const pythonSrcTmpl = `
 {{- define "METHOD" }}
     @staticmethod
-    @display_name("{{.NameABI }}")
+    {{- if ne .NameABI .Name}}
+    @display_name("{{.NameABI }}"){{end}}
     def {{.Name}}({{range $index, $arg := .Arguments -}}
        {{- if ne $index 0}}, {{end}}
           {{- .Name}}: {{.Type}}

--- a/generators/python.go
+++ b/generators/python.go
@@ -27,6 +27,7 @@ import (
 const pythonSrcTmpl = `
 {{- define "METHOD" }}
     @staticmethod
+    @display_name("{{.NameABI }}")
     def {{.Name}}({{range $index, $arg := .Arguments -}}
        {{- if ne $index 0}}, {{end}}
           {{- .Name}}: {{.Type}}
@@ -34,7 +35,7 @@ const pythonSrcTmpl = `
         pass
 {{- end -}}
 from boa3.builtin.type import UInt160, UInt256, ECPoint
-from boa3.builtin.compile_time import contract
+from boa3.builtin.compile_time import contract, display_name
 from typing import cast, Any
 
 


### PR DESCRIPTION
The python SDK generator automatically converts the ABI method name to snake case to have a pythonic methods in the SDK. e.g. 
```json
methods": [
            {
                "name": "HelloWorld",
                "offset": 0,
                "parameters": [],
                "safe": false,
                "returntype": "String"
            }
        ],
```
translates to
```python
@staticmethod
    def hello_world() -> str: 
        pass
```
which looks nice and pythonic when the SDK is used, but when it is compiled the VM will try to call the method `hello_world` on the contract instead of `HelloWorld` which doesn't work.


Adding the `display_name` decorator solves this. 