### PR TITLE
cli: add a command to show CPM's version

### DIFF
--- a/main.go
+++ b/main.go
@@ -437,7 +437,7 @@ func handleCliGenerate(cCtx *cli.Context, language string) error {
 }
 
 func handleCliVersion(cCtx *cli.Context) error {
-	fmt.Printf("cpm %s", version)
+	fmt.Printf("cpm %s\n", version)
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -38,6 +38,8 @@ var (
 
 	SDK_OFFCHAIN = "offchain"
 	SDK_ONCHAIN  = "onchain"
+
+	version = "dev"
 )
 
 var GenerateCommandHelpTemplate = `NAME:
@@ -196,6 +198,11 @@ func main() {
 						},
 					},
 				},
+			},
+			{
+				Name:   "version",
+				Usage:  "Shows CPM version",
+				Action: handleCliVersion,
 			},
 		},
 	}
@@ -427,6 +434,11 @@ func handleCliGenerate(cCtx *cli.Context, language string) error {
 		}
 	}
 	return generateSDK(&generators.GenerateCfg{Manifest: m, ContractHash: scriptHash, SdkDestination: dest}, language, sdkType)
+}
+
+func handleCliVersion(cCtx *cli.Context) error {
+	fmt.Printf("cpm %s", version)
+	return nil
 }
 
 func fetchManifestAndGenerateSDK(c *ContractConfig, host string) error {


### PR DESCRIPTION
I was not able to fully test this, because it depends on `goreleaser`.

The variable[ `version` from the `main` package](https://goreleaser.com/cookbooks/using-main.version/) should be overwritten when goreleaser starts running. So, if I try to use the version CLI command on a repo clone it should print `cpm dev`, but if I use the version CLI command from a release it should print `cpm { the release version }`