### PR TITLE
cli: rework `cpm run` command

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,15 +15,21 @@ import (
 
 //go:embed cpm.yaml.default
 var defaultConfig []byte
-var cfg *CPMConfig
+var cfg = &CPMConfig{
+	Defaults: Defaults{
+		ContractGenerateSdk: false,
+		ContractDownload:    true,
+	},
+}
 
 type ContractConfig struct {
-	Label               string          `yaml:"label"`
-	ScriptHash          util.Uint160    `yaml:"script-hash"`
-	SourceNetwork       *string         `yaml:"source-network,omitempty"`
-	ContractGenerateSdk *bool           `yaml:"contract-generate-sdk,omitempty"`
-	OnChain             *GenerateConfig `yaml:"on-chain,omitempty"`
-	OffChain            *GenerateConfig `yaml:"off-chain,omitempty"`
+	Label         string          `yaml:"label"`
+	ScriptHash    util.Uint160    `yaml:"script-hash"`
+	SourceNetwork *string         `yaml:"source-network,omitempty"`
+	GenerateSdk   *bool           `yaml:"generate-sdk,omitempty"`
+	Download      *bool           `yaml:"download,omitempty"`
+	OnChain       *GenerateConfig `yaml:"on-chain,omitempty"`
+	OffChain      *GenerateConfig `yaml:"off-chain,omitempty"`
 }
 
 type GenerateConfig struct {
@@ -39,14 +45,17 @@ type SdkDestination struct {
 	TS     *string `yaml:"ts,omitempty"`
 }
 
+type Defaults struct {
+	ContractSourceNetwork string          `yaml:"contract-source-network"`
+	ContractDestination   string          `yaml:"contract-destination"`
+	ContractGenerateSdk   bool            `yaml:"contract-generate-sdk"`
+	ContractDownload      bool            `yaml:"contract-download,omitempty"`
+	OnChain               *GenerateConfig `yaml:"on-chain,omitempty"`
+	OffChain              *GenerateConfig `yaml:"off-chain,omitempty"`
+}
+
 type CPMConfig struct {
-	Defaults struct {
-		ContractSourceNetwork string          `yaml:"contract-source-network"`
-		ContractDestination   string          `yaml:"contract-destination"`
-		ContractGenerateSdk   bool            `yaml:"contract-generate-sdk"`
-		OnChain               *GenerateConfig `yaml:"on-chain,omitempty"`
-		OffChain              *GenerateConfig `yaml:"off-chain,omitempty"`
-	} `yaml:"defaults"`
+	Defaults  Defaults         `yaml:"defaults"`
 	Contracts []ContractConfig `yaml:"contracts"`
 	Tools     struct {
 		NeoExpress struct {
@@ -83,8 +92,11 @@ func LoadConfig() {
 		if c.SourceNetwork == nil {
 			cfg.Contracts[i].SourceNetwork = &cfg.Defaults.ContractSourceNetwork
 		}
-		if c.ContractGenerateSdk == nil {
-			cfg.Contracts[i].ContractGenerateSdk = &cfg.Defaults.ContractGenerateSdk
+		if c.GenerateSdk == nil {
+			cfg.Contracts[i].GenerateSdk = &cfg.Defaults.ContractGenerateSdk
+		}
+		if c.Download == nil {
+			cfg.Contracts[i].Download = &cfg.Defaults.ContractDownload
 		}
 	}
 }

--- a/config.go
+++ b/config.go
@@ -4,7 +4,7 @@ import (
 	"cpm/generators"
 	_ "embed"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -82,7 +82,7 @@ func LoadConfig() {
 	}
 	defer f.Close()
 
-	yamlData, _ := ioutil.ReadAll(f)
+	yamlData, _ := io.ReadAll(f)
 	if err := yaml.Unmarshal(yamlData, &cfg); err != nil {
 		log.Fatal(fmt.Errorf("failed to parse config file: %w", err))
 	}

--- a/cpm.yaml.default
+++ b/cpm.yaml.default
@@ -3,6 +3,7 @@ defaults:
   contract-source-network: mainnet
   contract-destination: neo-express
   contract-generate-sdk: false
+  contract-download: true
   # settings related to SDK generation for on chain contracts
   on-chain:
     # both languages and destinations take the same key values: csharp, go, java or python
@@ -30,11 +31,13 @@ contracts:
     # the unique identifier used to download the contract
     script-hash: '0x76a8f8a7a901b29a33013b469949f4b08db15756'
     # overrides the default for this contract specifically
-    contract-generate-sdk: true
+    generate-sdk: true
   - label: Props - generator
     script-hash: '0x0e312c70ce6ed18d5702c6c5794c493d9ef46dc9'
   - label: Props - dice
     script-hash: '0x4380f2c1de98bb267d3ea821897ec571a04fe3e0'
+    # overrides the default for this contract specifically
+    download: false
   - label: Props - collection
     script-hash: '0xf05651bc505fd5c7d36593f6e8409932342f9085'
 # which tools are available for contract downloading and/or generating SDKs

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,20 +1,21 @@
 `cpm.yaml` is your project configuration file. It holds all information about which contracts it should download,
 from which network and whether it should generate an SDK. Depending on the SDK type generated it allows it to either be
-consumed in the smart contract you're developing (=on-chain), or to be consumed in some backend to interact with the smart
+consumed in the smart contract you're developing (=on-chain), or to be consumed in a backend to interact with the smart
 contract you developed once deployed (=off-chain).
 
 It has 4 major sections which will be described in detail later on
 * `defaults` - this section holds settings that apply to all contracts unless explicitly overridden in the `contracts` section.
-* `contracts` - this section describes which contracts to download with what options.
+* `contracts` - this section describes which contracts to download or generate SDKs for and with what options.
 * `tools` - this section describes the available tools and if they can be used for contract downloading and/or generating SDKs.
 * `networks` - this section holds a list of networks with corresponding RPC server addresses to the networks used for source information downloading.
 
 # defaults
 * `contract-source-network` - describes which network is the source for downloading contracts from. Valid values are [networks.label](#Networks)s.
 * `contract-destination` - describe where the downloaded contract should be persisted. Valid values are [contract-destination](#contract-destination) keys.
-* `contract-generate-sdk` - set to `true` to generate SDKs based on the contract manifest that can be consumed in your smart contract.
-* `on-chain` - describes settings for generating SDKs for use in on chain contracts. See [GenerateConfig](#GenerateConfig)
-* `off-chain` - describes settings for generating off-chain SDKs to interact with on chain contracts. See [GenerateConfig](#GenerateConfig)
+* `contract-download` - set to `true` to download all [contracts](#contracts) to your local chain.
+* `contract-generate-sdk` - set to `true` to generate SDKs for all [contracts](#contracts).
+* `on-chain` - describes settings for generating SDKs for use in on chain contracts. See [GenerateConfig](#GenerateConfig).
+* `off-chain` - describes settings for generating off-chain SDKs to interact with on chain contracts. See [GenerateConfig](#GenerateConfig).
 
 
 ## GenerateConfig
@@ -41,7 +42,8 @@ It has 4 major sections which will be described in detail later on
 * `label` - a user defined label to identify the target contract in the config. Must be a string. Not used elsewhere.
 * `script-hash` - the script hash identifying the contract in `0x<hash>` format. i.e. `0x36d0bf624b90a9dad39d85dcafc83f14dab0272f`.
 * `source-network` - (Optional) overrides the `contract-source-network` setting in `defaults` to set the source for downloading the contract from. Valid values are [networks.label](#Networks)s.
-* `contract-generate-sdk` - (Optional) overrides the `contract-generate-sdk` setting in `defaults` to generate an SDK. Must be a bool value.
+* `generate-sdk` - (Optional) overrides the `contract-generate-sdk` setting in `defaults` to generate an SDK. Must be a bool value.
+* `download` - (Optional) overrides the `contract-download` setting in `defaults` to download a contract to the local chain. Must be a bool value.
 
 # tools
 Currently `neo-express` is the only tool that supports downloading contracts. An [issue](https://github.com/nspcc-dev/neo-go/issues/2406) exists for `neo-go` to add download support.

--- a/docs/config.md
+++ b/docs/config.md
@@ -11,7 +11,6 @@ It has 4 major sections which will be described in detail later on
 
 # defaults
 * `contract-source-network` - describes which network is the source for downloading contracts from. Valid values are [networks.label](#Networks)s.
-* `contract-destination` - describe where the downloaded contract should be persisted. Valid values are [contract-destination](#contract-destination) keys.
 * `contract-download` - set to `true` to download all [contracts](#contracts) to your local chain.
 * `contract-generate-sdk` - set to `true` to generate SDKs for all [contracts](#contracts).
 * `on-chain` - describes settings for generating SDKs for use in on chain contracts. See [GenerateConfig](#GenerateConfig).


### PR DESCRIPTION
`cpm run` would always download contracts unless the `sdk-only` flag was specified on the CLI. There was no way to override this behaviour in the `defaults` section of the config. Only on a per contract basis. `cpm run` is intended to always use the config, so the `sdk-only` and `download-only` CLI flags went against that idea, it also led to somewhat messy code. 

This PR reworks the whole command by removing the flags and only reading settings from `cpm.yaml`. Specifically

- remove `download-only` flag from `cpm run`. Is now only configurable through `cpm.yaml` as `defaults.contract-download-sdk`
- remove `sdk-only` flag from `cpm run`. Is now only configurable through `cpm.yaml` as `defaults.contract-generate-sdk`
- rename `contract-generate-sdk` to `generate-sdk` for the `contracts` specific section
- rename `contract-download-sdk` to `download` for the `contracts` specific section
- add `contract-download` to the `defaults` section. Previously this was always `true`
- add more debug logging around `cpm run` functionality

**This contains breaking changes to the config file**
