### PR TITLE
ci: automate Unix & Windows draft release merging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: goreleaser
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - '*'
@@ -27,8 +28,16 @@ jobs:
           args: release --clean --config .goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GH_HOMEBREW_TAP }}
+      - uses: actions/cache@v3
+        env:
+          cache-name: cpm-dist
+        with:
+          path: ./dist
+          enableCrossOsArchive: true
+          key: dist-unix
   goreleaser-windows:
     runs-on: windows-latest
+    needs: goreleaser-unix
     steps:
       - uses: actions/checkout@v3
         with:
@@ -46,3 +55,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+      - uses: actions/cache@v3
+        env:
+          cache-name: cpm-dist
+        with:
+          path: ./dist
+          enableCrossOsArchive: true
+          key: dist-windows
+  merge-dist:
+    runs-on: ubuntu-latest
+    needs: goreleaser-windows
+    steps:
+      - name: restore Unix dist cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cpm-dist
+        with:
+          path: ./dist
+          enableCrossOsArchive: true
+          key: dist-unix
+          restore-keys: |
+            dist-unix
+      - name: restore Windows dist cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cpm-dist
+        with:
+          path: ./dist
+          enableCrossOsArchive: true
+          key: dist-windows
+          restore-keys: |
+            dist-windows
+      - name: Remove unnecessary files before release
+        run: |
+          ls -la ./dist
+          rm -rf ./dist/*/
+          rm ./dist/config.yaml
+          rm ./dist/metadata.json
+          rm ./dist/checksums.txt
+      - name: Create draft release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          name: Draft
+          files: ./dist/*.*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: goreleaser
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - '*'

--- a/.goreleaser-windows.yaml
+++ b/.goreleaser-windows.yaml
@@ -50,8 +50,3 @@ chocolateys:
     api_key: '{{ .Env.CHOCOLATEY_API_KEY }}'
     source_repo: "https://push.chocolatey.org/"
     skip_publish: false
-
-# Github release
-release:
-  draft: true
-  replace_existing_draft: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,11 +40,6 @@ nfpms:
       - rpm
       - archlinux
 
-# Github release
-release:
-  draft: true
-  replace_existing_draft: false
-
 # OSX homebrew tap
 brews:
   -


### PR DESCRIPTION
9017d9c8c1499519f20b20d1240d9545ef2d43f1 forced the release process to use a Windows runner in order to build the Chocolatey packages. This came at a cost of having GoReleaser create 2 Draft releases that had to be merged manually. This PR drops the builtin function and manually merges the `/dist` directories of both build jobs, then removes some unnecessary files (and directories) and finally uses a 3rd party action to create a draft release.

Note: we still have to publish the draft within 30 minutes after creation for the Chocolatey verification process to automatically pick it up.