### PR TITLE
java: fix onchain contract method names

### DIFF
--- a/generators/java/offchain.go
+++ b/generators/java/offchain.go
@@ -60,7 +60,7 @@ const javaOffChainSrcTmpl = `
 		{{-  end }}
 	}
 {{- end -}}
-package <REPLACE ME>
+package <REPLACE ME>;
 
 import io.neow3j.contract.SmartContract;
 import io.neow3j.crypto.ECKeyPair;

--- a/generators/java/onchain.go
+++ b/generators/java/onchain.go
@@ -14,12 +14,12 @@ import (
 
 const javaSrcTmpl = `
 {{- define "METHOD" }}
-    public native {{.ReturnType }} {{.Name}}({{range $index, $arg := .Arguments -}}
+    public native {{.ReturnType }} {{.NameABI}}({{range $index, $arg := .Arguments -}}
        {{- if ne $index 0}}, {{end}}
           {{- .Type}} {{.Name}}
        {{- end}});
 {{- end -}}
-package <REPLACE_ME>
+package <REPLACE_ME>;
 
 import io.neow3j.devpack.*;
 import io.neow3j.devpack.contracts.ContractInterface;


### PR DESCRIPTION
When creating an onchain Java SDK, the SDK would be generating method names that were always in camelCase, this ends up resulting in an error when calling methods that were following another naming standard (e.g. Dice from props that is using snake_case) 

Also added a `;` at the first line on the onchain and offchain SDKs