### PR TITLE
ci: resolve deprecation warnings and errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
           rm ./dist/config.yaml
           rm ./dist/metadata.json
           rm ./dist/checksums.txt
+          rm ./dist/checksums_windows.txt
       - name: Create draft release
         uses: softprops/action-gh-release@v1
         with:

--- a/.goreleaser-windows.yaml
+++ b/.goreleaser-windows.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
 project_name: cpm
 before:
   hooks:
@@ -15,11 +16,11 @@ builds:
       - amd64
       - arm64
 archives:
-  - format: zip
+  - formats: zip
 checksum:
-  name_template: 'checksums.txt'
+  name_template: 'checksums_windows.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
 project_name: cpm
 before:
   hooks:
@@ -18,7 +19,7 @@ builds:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
@@ -41,7 +42,7 @@ nfpms:
       - archlinux
 
 # OSX homebrew tap
-brews:
+homebrew_casks:
   -
     repository:
       owner: CityOfZion


### PR DESCRIPTION
- We rename the `checksums.txt` for windows to avoid duplication conflicts when pushed on release
- Other changes are all deprecation warnings by goreleaser and changed based on the migration guide