### PR TITLE
cli: fix default value for `-s` flag of download contract manifest command

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 							&cli.StringFlag{Name: "c", Usage: "Contract script hash", Required: true},
 							&cli.StringFlag{Name: "n", Usage: "Source network label. Searches cpm.yaml for the network by label to find the host", Required: false},
 							&cli.StringFlag{Name: "N", Usage: "Source network host", Required: false},
-							&cli.BoolFlag{Name: "s", Usage: "Save contract to the 'contracts' section of cpm.yaml", Required: false, Value: true, DisableDefaultText: true},
+							&cli.BoolFlag{Name: "s", Usage: "Save contract to the 'contracts' section of cpm.yaml", Required: false, Value: false, DisableDefaultText: true},
 						},
 						Action: handleCliDownloadManifest,
 					},


### PR DESCRIPTION
The flag is used to indicate that it should store to `cpm.yaml` so the default value should be `false` similar to 
https://github.com/CityOfZion/cpm/blob/c81bdba20b6d9b9e1f24dee425b4468ae0be6c55/main.go#L100